### PR TITLE
Support masterless nodes without PuppetDB

### DIFF
--- a/data/testing.yaml
+++ b/data/testing.yaml
@@ -16,4 +16,4 @@ vision_puppet::r10k::remote_path_puppet: '/puppet/path/foobar'
 vision_puppet::puppetdb::sql_user: 'foobar'
 vision_puppet::puppetdb::sql_password: 'foobar'
 
-vision_puppet::masterless::puppetdb_server: 'https://example.com:8081/'
+vision_puppet::masterless:puppet_conf_dir: '/data'

--- a/spec/acceptance/masterless-puppetdb_spec.rb
+++ b/spec/acceptance/masterless-puppetdb_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper_acceptance'
+
+describe 'vision_puppet::masterless' do
+  context 'with defaults' do
+    it 'idempotentlies run' do
+      pp = <<-FILE
+        package { 'unzip':
+          ensure => present,
+        }
+        class { 'vision_puppet::masterless':
+          puppetdb_server => 'https://my.example.com:8081/',
+          puppet_conf_dir => '/data',
+        }
+      FILE
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+
+    end
+  end
+
+  context 'files provisioned' do
+    describe file('/data/puppet.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_mode 744 }
+      it { is_expected.to contain 'storeconfigs = true' }
+      it { is_expected.to contain 'storeconfigs_backend = puppetdb' }
+      it { is_expected.to contain 'facts_terminus = facter' }
+      it { is_expected.to contain 'This file is managed by puppet' }
+    end
+
+    describe file('/data/puppetdb.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'server_urls = https://my.example.com:8081/' }
+      it { is_expected.to contain 'MANAGED BY PUPPET' }
+    end
+
+    describe file('/data/routes.yaml') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'apply:' }
+      it { is_expected.to contain 'terminus: compiler' }
+      it { is_expected.to contain 'cache: puppetdb' }
+      it { is_expected.to contain 'terminus: facter' }
+      it { is_expected.to contain 'cache: puppetdb_apply' }
+
+      it { is_expected.not_to contain 'cache: yaml' }
+    end
+
+    describe file('/etc/apt/preferences.d/puppet-agent.pref') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'This file is managed by Puppet. DO NOT EDIT.' }
+      it { is_expected.to contain 'Package: puppet-agent' }
+      it { is_expected.to contain 'Pin: version 1.2.3' }
+      it { is_expected.to contain 'Pin-Priority: 999' }
+    end
+
+    describe package('puppet-agent') do
+      it { is_expected.to be_installed }
+    end
+
+    describe package('puppetdb-termini') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('puppet') do
+      it { is_expected.not_to be_running }
+      it { is_expected.not_to be_enabled }
+    end
+  end
+end

--- a/spec/acceptance/masterless_puppetdb_spec.rb
+++ b/spec/acceptance/masterless_puppetdb_spec.rb
@@ -15,7 +15,6 @@ describe 'vision_puppet::masterless' do
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
-
     end
   end
 

--- a/spec/acceptance/masterless_spec.rb
+++ b/spec/acceptance/masterless_spec.rb
@@ -14,7 +14,6 @@ describe 'vision_puppet::masterless' do
 
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
-
     end
   end
 

--- a/templates/puppet-masterless.conf.erb
+++ b/templates/puppet-masterless.conf.erb
@@ -9,6 +9,10 @@ logdir = /var/log/puppetlabs/puppet
 vardir = /opt/puppetlabs/puppet/cache
 rundir = /var/run/puppetlabs
 codedir = /etc/puppetlabs/code
+facts_terminus = facter
+<% if defined?(@puppetdb_server) -%>
 storeconfigs = true
 storeconfigs_backend = puppetdb
-facts_terminus = facter
+<% else -%>
+storeconfigs = false
+<% end -%>

--- a/templates/routes-masterless.yaml.erb
+++ b/templates/routes-masterless.yaml.erb
@@ -1,8 +1,14 @@
 ---
 apply:
+<% if defined?(@puppetdb_server) -%>
   catalog:
     terminus: compiler
     cache: puppetdb
   facts:
     terminus: facter
     cache: puppetdb_apply
+<% else -%>
+  facts:
+    terminus: facter
+    cache: yaml
+<% end -%>


### PR DESCRIPTION
Mainly changes `puppet.conf` and `routes.yaml`, though some other changes are required in the testing suite.