### PR TITLE
Manage SSH keys for access to Puppet Git repositories

### DIFF
--- a/data/testing.yaml
+++ b/data/testing.yaml
@@ -19,3 +19,12 @@ vision_puppet::puppetdb::sql_password: 'foobar'
 vision_puppet::masterless:puppet_conf_dir: '/data'
 vision_puppet::masterless:interval: '42h'
 vision_puppet::masterless:log_level: 'debug'
+
+vision_puppet::keys::hosts:
+  - host: 'git.example.com'
+    user: 'foo'
+    port: '2222'
+  - host: 'gitlab.com'
+    user: 'git'
+vision_puppet::keys::public_key: 'my-public-key'
+vision_puppet::keys::private_key: 'my-secret-key'

--- a/manifests/keys.pp
+++ b/manifests/keys.pp
@@ -1,0 +1,34 @@
+# Class: vision_puppet::keys
+# ===========================
+#
+# Profile to manage SSH keys for Puppet repos
+
+class vision_puppet::keys (
+  String $public_key,
+  String $private_key,
+  Array[Hash] $hosts,
+  String $identityfile = '/root/.ssh/puppetdeploy',
+  ) {
+
+  file { $identityfile:
+    ensure  => present,
+    owner   => 'root',
+    mode    => '0600',
+    content => $private_key,
+  }
+
+  file { "${identityfile}.pub":
+    ensure  => present,
+    owner   => 'root',
+    mode    => '0600',
+    content => $public_key,
+  }
+
+  file { '/root/.ssh/config':
+    ensure  => present,
+    owner   => 'root',
+    mode    => '0644',
+    content => template('vision_puppet/ssh_config.erb'),
+  }
+
+}

--- a/manifests/r10k.pp
+++ b/manifests/r10k.pp
@@ -23,7 +23,9 @@ class vision_puppet::r10k(
   String $g10k_url      = 'https://github.com/xorpaul/g10k/releases/download/v0.5.8/g10k-linux-amd64.zip',
   String $g10k_checksum = '1fee326742e6c90efb23683cbc0063b7dfbdbe1b5a91a98990036a70d5563a33',
 
-) {
+  ) {
+
+  contain ::vision_puppet::keys
 
   # Temporary cause of duplicate resource with sys
   # if !defined(Package['unzip']) {

--- a/spec/acceptance/keys_spec.rb
+++ b/spec/acceptance/keys_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper_acceptance'
+
+describe 'vision_puppet::keys' do
+  context 'with defaults' do
+    it 'idempotentlies run' do
+      pp = <<-FILE
+        class { 'vision_puppet::keys': }
+      FILE
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+
+  context 'files provisioned' do
+    describe file('/root/.ssh/config') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_mode 644 }
+      its(:content) { is_expected.to match 'managed by Puppet' }
+      its(:content) { is_expected.to match 'Host git.example.com' }
+      its(:content) { is_expected.to match 'User foo' }
+      its(:content) { is_expected.to match 'Port 2222' }
+      its(:content) { is_expected.to match 'IdentityFile /root/.ssh/puppetdeploy' }
+      its(:content) { is_expected.to match 'BatchMode yes' }
+      its(:content) { is_expected.to match 'Host gitlab.com' }
+    end
+
+    describe file('/root/.ssh/puppetdeploy') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_mode 600 }
+      its(:content) { is_expected.to match 'my-secret-key' }
+    end
+
+    describe file('/root/.ssh/puppetdeploy.pub') do
+      it { is_expected.to be_file }
+      it { is_expected.to be_mode 600 }
+      its(:content) { is_expected.to match 'my-public-key' }
+    end
+  end
+end

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -1,0 +1,13 @@
+# This file is managed by Puppet
+# see ssh_config(5)
+<% @hosts.each do |h| -%>
+Host <%= h["host"] %>
+  <% if defined?(h["user"]) -%>
+  User <%= h["user"] %>
+  <% end -%>
+  <% if defined?(h["port"]) -%>
+  Port <%= h["port"] %>
+  <% end -%>
+  IdentityFile <%= @identityfile %>
+  BatchMode yes
+<% end -%>


### PR DESCRIPTION
Manage /root/.ssh/{config,puppetdeploy,puppetdeploy.pub} via Puppet

Do not merge yet, keys will need to be added to hiera first.